### PR TITLE
make namespace tagger hook more resilient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Make namespace-tagger hook more resilient. ([#29](https://github.com/giantswarm/linkerd2-app/pull/29))
+
 ## [0.5.0] - 2020-12-17
 
 ### Changed

--- a/helm/linkerd2-app/templates/hooks/hook-pre-install-annotate-namespace.yaml
+++ b/helm/linkerd2-app/templates/hooks/hook-pre-install-annotate-namespace.yaml
@@ -1,15 +1,16 @@
+{{ $hookName := "namespace-tagger" -}}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: namespace-tagger
+  name: {{ $hookName }}
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": "pre-install,pre-upgrade"
     "helm.sh/hook-weight": "-20"
-    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
   labels:
-    app: namespace-tagger
+    app: {{ $hookName }}
 rules:
 - apiGroups:
   - ""
@@ -31,52 +32,52 @@ rules:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: namespace-tagger
+  name: {{ $hookName }}
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": "pre-install,pre-upgrade"
     "helm.sh/hook-weight": "-15"
-    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
   labels:
-    app: namespace-tagger
+    app: {{ $hookName }}
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: namespace-tagger
+  name: {{ $hookName }}
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": "pre-install,pre-upgrade"
     "helm.sh/hook-weight": "-14"
-    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
   labels:
-    app: namespace-tagger
+    app: {{ $hookName }}
 subjects:
   - kind: ServiceAccount
-    name: namespace-tagger
+    name: {{ $hookName }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
-  name: namespace-tagger
+  name: {{ $hookName }}
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: namespace-tagger
+  name: {{ $hookName }}
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": "pre-install,pre-upgrade"
     "helm.sh/hook-weight": "-10"
-    "helm.sh/hook-delete-policy": "hook-succeeded,hook-failed"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded,hook-failed"
   labels:
-    app: namespace-tagger
+    app: {{ $hookName }}
 spec:
   template:
     spec:
-      serviceAccountName: namespace-tagger
+      serviceAccountName: {{ $hookName }}
       containers:
-      - name: namespace-tagger
+      - name: {{ $hookName }}
         image: "{{ .Values.kubectlImage.registry }}/{{ .Values.kubectlImage.name }}:{{ .Values.kubectlImage.tag }}"
         imagePullPolicy: "{{ .Values.kubectlImage.pullPolicy }}"
         command:
@@ -88,6 +89,5 @@ spec:
           kubectl annotate --overwrite ns {{ .Release.Namespace }} {{.Values.global.proxyInjectAnnotation}}={{.Values.global.proxyInjectDisabled}};
           kubectl label --overwrite ns {{ .Release.Namespace }} {{.Values.global.linkerdNamespaceLabel}}="true";
           kubectl label --overwrite ns {{ .Release.Namespace }} config.linkerd.io/admission-webhooks=disabled;
-          kubectl -n {{ .Release.Namespace }} delete configmap linkerd-config || true;
       restartPolicy: Never
   backoffLimit: 6


### PR DESCRIPTION
```
  reason: 'Upgrade "linkerd2-app" failed: pre-upgrade hooks failed: warning: Hook
    pre-upgrade linkerd2-app/templates/hooks/hook-pre-install-annotate-namespace.yaml
    failed: roles.rbac.authorization.k8s.io "namespace-tagger" already exists'
```