### PR TITLE
Add team label to all resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Add Giant Swarm team label to resources.
+
 ## [0.7.1] - 2022-08-03
 
 ### Changed

--- a/helm/linkerd2-app/templates/_gs-helpers.tpl
+++ b/helm/linkerd2-app/templates/_gs-helpers.tpl
@@ -1,0 +1,4 @@
+{{- define "linkerd.giantswarm-labels" -}}
+giantswarm.io/service-type: "managed"
+application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
+{{- end -}}

--- a/helm/linkerd2-app/templates/config.yaml
+++ b/helm/linkerd2-app/templates/config.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: controller
     linkerd.io/control-plane-ns: {{.Values.namespace}}
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
 data:

--- a/helm/linkerd2-app/templates/destination-rbac.yaml
+++ b/helm/linkerd2-app/templates/destination-rbac.yaml
@@ -9,6 +9,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: {{.Values.namespace}}
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
 rules:
 - apiGroups: ["apps"]
   resources: ["replicasets"]
@@ -38,6 +39,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: {{.Values.namespace}}
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -55,6 +57,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: {{.Values.namespace}}
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
 {{- include "partials.image-pull-secrets" .Values.imagePullSecrets }}
 ---
 {{- $host := printf "linkerd-sp-validator.%s.svc" .Values.namespace }}
@@ -68,6 +71,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: {{.Values.namespace}}
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
 type: kubernetes.io/tls
@@ -83,6 +87,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: {{.Values.namespace}}
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
 webhooks:
 - name: linkerd-sp-validator.linkerd.io
   namespaceSelector:
@@ -116,6 +121,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: {{.Values.namespace}}
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
 type: kubernetes.io/tls
@@ -131,6 +137,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: {{.Values.namespace}}
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
 webhooks:
 - name: linkerd-policy-validator.linkerd.io
   namespaceSelector:
@@ -163,6 +170,7 @@ metadata:
     app.kubernetes.io/part-of: Linkerd
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: {{.Values.namespace}}
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
 rules:
   - apiGroups:
       - ""
@@ -190,6 +198,7 @@ metadata:
     app.kubernetes.io/part-of: Linkerd
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: {{.Values.namespace}}
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/helm/linkerd2-app/templates/destination.yaml
+++ b/helm/linkerd2-app/templates/destination.yaml
@@ -10,6 +10,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: {{.Values.namespace}}
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
 spec:
@@ -29,6 +30,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: {{.Values.namespace}}
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
 spec:
@@ -48,6 +50,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: {{.Values.namespace}}
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
 spec:
@@ -67,6 +70,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: {{.Values.namespace}}
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
 spec:
@@ -86,6 +90,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: {{.Values.namespace}}
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
 spec:
@@ -106,6 +111,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: {{.Values.namespace}}
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
 spec:
@@ -131,6 +137,7 @@ metadata:
     linkerd.io/control-plane-component: destination
     linkerd.io/control-plane-ns: {{.Values.namespace}}
     giantswarm.io/monitoring_basic_sli: "true"
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
   name: linkerd-destination
   namespace: {{.Values.namespace}}
 spec:
@@ -159,6 +166,7 @@ spec:
         linkerd.io/control-plane-component: destination
         linkerd.io/control-plane-ns: {{.Values.namespace}}
         linkerd.io/workload-ns: {{.Values.namespace}}
+        {{- include "linkerd.giantswarm-labels" . | nindent 8 }}
         {{- include "partials.proxy.labels" $tree.Values.proxy | nindent 8}}
         {{- with .Values.podLabels }}{{ toYaml . | trim | nindent 8 }}{{- end }}
     spec:

--- a/helm/linkerd2-app/templates/heartbeat-rbac.yaml
+++ b/helm/linkerd2-app/templates/heartbeat-rbac.yaml
@@ -10,6 +10,7 @@ metadata:
   namespace: {{.Values.namespace}}
   labels:
     linkerd.io/control-plane-ns: {{.Values.namespace}}
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
 rules:
 - apiGroups: [""]
   resources: ["configmaps"]
@@ -23,6 +24,7 @@ metadata:
   namespace: {{.Values.namespace}}
   labels:
     linkerd.io/control-plane-ns: {{.Values.namespace}}
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
 roleRef:
   kind: Role
   name: linkerd-heartbeat
@@ -38,6 +40,7 @@ metadata:
   name: linkerd-heartbeat
   labels:
     linkerd.io/control-plane-ns: {{.Values.namespace}}
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
 rules:
 - apiGroups: [""]
   resources: ["namespaces"]
@@ -52,6 +55,7 @@ metadata:
   name: linkerd-heartbeat
   labels:
     linkerd.io/control-plane-ns: {{.Values.namespace}}
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
 roleRef:
   kind: ClusterRole
   name: linkerd-heartbeat
@@ -69,5 +73,6 @@ metadata:
   labels:
     linkerd.io/control-plane-component: heartbeat
     linkerd.io/control-plane-ns: {{.Values.namespace}}
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
 {{- include "partials.image-pull-secrets" .Values.imagePullSecrets }}
 {{- end }}

--- a/helm/linkerd2-app/templates/heartbeat.yaml
+++ b/helm/linkerd2-app/templates/heartbeat.yaml
@@ -14,6 +14,7 @@ metadata:
     app.kubernetes.io/version: {{default .Values.linkerdVersion .Values.controllerImageVersion}}
     linkerd.io/control-plane-component: heartbeat
     linkerd.io/control-plane-ns: {{.Values.namespace}}
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
 spec:
@@ -31,6 +32,7 @@ spec:
           labels:
             linkerd.io/control-plane-component: heartbeat
             linkerd.io/workload-ns: {{.Values.namespace}}
+            {{- include "linkerd.giantswarm-labels" . | nindent 12 }}
             {{- with .Values.podLabels }}{{ toYaml . | trim | nindent 12 }}{{- end }}
           annotations:
             {{ include "partials.annotations.created-by" . }}

--- a/helm/linkerd2-app/templates/identity-rbac.yaml
+++ b/helm/linkerd2-app/templates/identity-rbac.yaml
@@ -10,6 +10,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: {{.Values.namespace}}
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
 rules:
 - apiGroups: ["authentication.k8s.io"]
   resources: ["tokenreviews"]
@@ -28,6 +29,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: {{.Values.namespace}}
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -45,5 +47,6 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: {{.Values.namespace}}
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
 {{- include "partials.image-pull-secrets" .Values.imagePullSecrets }}
 {{ end -}}

--- a/helm/linkerd2-app/templates/identity.yaml
+++ b/helm/linkerd2-app/templates/identity.yaml
@@ -13,6 +13,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: {{.Values.namespace}}
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
 data:
@@ -29,6 +30,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: {{.Values.namespace}}
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
 data:
@@ -43,6 +45,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: {{.Values.namespace}}
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
 spec:
@@ -62,6 +65,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: {{.Values.namespace}}
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
 spec:
@@ -82,6 +86,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: {{.Values.namespace}}
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
 spec:
@@ -107,6 +112,7 @@ metadata:
     linkerd.io/control-plane-component: identity
     linkerd.io/control-plane-ns: {{.Values.namespace}}
     giantswarm.io/monitoring_basic_sli: "true"
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
   name: linkerd-identity
   namespace: {{.Values.namespace}}
 spec:
@@ -132,6 +138,7 @@ spec:
         linkerd.io/control-plane-component: identity
         linkerd.io/control-plane-ns: {{.Values.namespace}}
         linkerd.io/workload-ns: {{.Values.namespace}}
+        {{- include "linkerd.giantswarm-labels" . | nindent 8 }}
         {{- include "partials.proxy.labels" $tree.Values.proxy | nindent 8}}
         {{- with .Values.podLabels }}{{ toYaml . | trim | nindent 8 }}{{- end }}
     spec:

--- a/helm/linkerd2-app/templates/namespace.yaml
+++ b/helm/linkerd2-app/templates/namespace.yaml
@@ -13,4 +13,5 @@ metadata:
     linkerd.io/is-control-plane: "true"
     config.linkerd.io/admission-webhooks: disabled
     linkerd.io/control-plane-ns: {{.Values.namespace}}
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
 {{ end -}}

--- a/helm/linkerd2-app/templates/policy-crd.yaml
+++ b/helm/linkerd2-app/templates/policy-crd.yaml
@@ -8,6 +8,7 @@ metadata:
   labels:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     linkerd.io/control-plane-ns: {{.Values.namespace}}
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
 spec:
   group: policy.linkerd.io
   names:
@@ -153,6 +154,7 @@ metadata:
     {{ include "partials.annotations.created-by" . }}
   labels:
     linkerd.io/control-plane-ns: {{.Values.namespace}}
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
 spec:
   group: policy.linkerd.io
   scope: Namespaced

--- a/helm/linkerd2-app/templates/proxy-injector-rbac.yaml
+++ b/helm/linkerd2-app/templates/proxy-injector-rbac.yaml
@@ -9,6 +9,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: {{.Values.namespace}}
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
 rules:
 - apiGroups: [""]
   resources: ["events"]
@@ -33,6 +34,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: {{.Values.namespace}}
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
 subjects:
 - kind: ServiceAccount
   name: linkerd-proxy-injector
@@ -51,6 +53,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: {{.Values.namespace}}
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
 {{- include "partials.image-pull-secrets" .Values.imagePullSecrets }}
 ---
 {{- $host := printf "linkerd-proxy-injector.%s.svc" .Values.namespace }}
@@ -64,6 +67,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: {{.Values.namespace}}
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
 type: kubernetes.io/tls
@@ -79,6 +83,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: {{.Values.namespace}}
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
 webhooks:
 - name: linkerd-proxy-injector.linkerd.io
   namespaceSelector:

--- a/helm/linkerd2-app/templates/proxy-injector.yaml
+++ b/helm/linkerd2-app/templates/proxy-injector.yaml
@@ -18,6 +18,7 @@ metadata:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: {{.Values.namespace}}
     giantswarm.io/monitoring_basic_sli: "true"
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
   name: linkerd-proxy-injector
   namespace: {{.Values.namespace}}
 spec:
@@ -45,6 +46,7 @@ spec:
         linkerd.io/control-plane-component: proxy-injector
         linkerd.io/control-plane-ns: {{.Values.namespace}}
         linkerd.io/workload-ns: {{.Values.namespace}}
+        {{- include "linkerd.giantswarm-labels" . | nindent 8 }}
         {{- include "partials.proxy.labels" $tree.Values.proxy | nindent 8}}
         {{- with .Values.podLabels }}{{ toYaml . | trim | nindent 8 }}{{- end }}
     spec:
@@ -141,6 +143,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: {{.Values.namespace}}
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
     config.linkerd.io/opaque-ports: "443"
@@ -162,6 +165,7 @@ metadata:
   labels:
     linkerd.io/control-plane-component: proxy-injector
     linkerd.io/control-plane-ns: {{.Values.namespace}}
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
   annotations:
     {{ include "partials.annotations.created-by" . }}
 spec:

--- a/helm/linkerd2-app/templates/psp.yaml
+++ b/helm/linkerd2-app/templates/psp.yaml
@@ -9,6 +9,7 @@ metadata:
   name: linkerd-{{.Values.namespace}}-control-plane
   labels:
     linkerd.io/control-plane-ns: {{.Values.namespace}}
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
 spec:
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
@@ -65,6 +66,7 @@ metadata:
   namespace: {{.Values.namespace}}
   labels:
     linkerd.io/control-plane-ns: {{.Values.namespace}}
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
 rules:
 - apiGroups: ['policy', 'extensions']
   resources: ['podsecuritypolicies']
@@ -79,6 +81,7 @@ metadata:
   namespace: {{.Values.namespace}}
   labels:
     linkerd.io/control-plane-ns: {{.Values.namespace}}
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
 roleRef:
   kind: Role
   name: linkerd-psp

--- a/helm/linkerd2-app/templates/serviceprofile-crd.yaml
+++ b/helm/linkerd2-app/templates/serviceprofile-crd.yaml
@@ -10,6 +10,7 @@ metadata:
     {{ include "partials.annotations.created-by" . }}
   labels:
     linkerd.io/control-plane-ns: {{.Values.namespace}}
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
 spec:
   group: linkerd.io
   versions:

--- a/helm/linkerd2-app/templates/trafficsplit-crd.yaml
+++ b/helm/linkerd2-app/templates/trafficsplit-crd.yaml
@@ -11,6 +11,7 @@ metadata:
     {{ include "partials.annotations.created-by" . }}
   labels:
     linkerd.io/control-plane-ns: {{.Values.namespace}}
+    {{- include "linkerd.giantswarm-labels" . | nindent 4 }}
 spec:
   group: split.smi-spec.io
   scope: Namespaced


### PR DESCRIPTION
This PR adds the Giant Swarm team label to all resources

Towards https://github.com/giantswarm/giantswarm/issues/21304 and https://github.com/giantswarm/giantswarm/issues/22715
