### PR TITLE
Fix team annotation

### DIFF
--- a/helm/linkerd2-app/Chart.yaml
+++ b/helm/linkerd2-app/Chart.yaml
@@ -21,4 +21,4 @@ restrictions:
   clusterSingleton: true
   fixedNamespace: linkerd
 annotations:
-  application.giantswarm.io/team: team-cabbage
+  application.giantswarm.io/team: cabbage


### PR DESCRIPTION
The team annotation is used to route alerts about this app to cabbage rather than the provider team.
Unfortunately, adding the `team-` prefix to the annotation's value makes routing to fail, because opsgenie is looking for just "cabbage" rather than "team-cabbage":

![routing](https://user-images.githubusercontent.com/868430/183832787-48588109-41b6-4ef3-80cb-77f4f48a7d99.png)

![tag](https://user-images.githubusercontent.com/868430/183832909-ad605e1b-e46f-4b84-b702-85c46baccc1a.png)


## Checklist

- [ ] Automated test are working (for chart changes)
- [ ] I am confident my changes don't break existing installations (for chart changes)
- [ ] Changelog entry has been added
