### PR TITLE
templates: Remove post hook init hack when CNI is disabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Add image registry switch to automatically switch the used image registry based on the installation region
 
+### Removed
+
+- Post hook init hack when CNI is disabled since there's another init container around already.
+
 ## [0.7.4] - 2022-08-25
 
 ### Changed

--- a/helm/linkerd2-app/templates/destination.yaml
+++ b/helm/linkerd2-app/templates/destination.yaml
@@ -317,9 +317,6 @@ spec:
       */}}
       {{- $_ := set $tree.Values.proxyInit "ignoreOutboundPorts" "443" }}
       - {{- include "partials.proxy-init" $tree | indent 8 | trimPrefix (repeat 7 " ") }}
-      {{- if .Values.postHookInitHack.enabled -}}
-      - {{- include "post-hook-init-hack.container" . }}
-      {{- end }}
       {{- else if .Values.postHookInitHack.enabled }}
       initContainers:
       - {{- include "post-hook-init-hack.container" . | indent 8 | trimPrefix (repeat 7 " ") }}

--- a/helm/linkerd2-app/templates/proxy-injector.yaml
+++ b/helm/linkerd2-app/templates/proxy-injector.yaml
@@ -112,9 +112,6 @@ spec:
       {{ if not .Values.cniEnabled -}}
       initContainers:
       - {{- include "partials.proxy-init" $tree | indent 8 | trimPrefix (repeat 7 " ") }}
-      {{- if .Values.postHookInitHack.enabled -}}
-      - {{- include "post-hook-init-hack.container" . }}
-      {{- end }}
       {{- else if .Values.postHookInitHack.enabled }}
       initContainers:
       - {{- include "post-hook-init-hack.container" . | indent 8 | trimPrefix (repeat 7 " ") }}


### PR DESCRIPTION
Didn't render anway...

- **This repository allows merge commits, if you're creating a Release, make sure to select 'Squash and merge'**
- **When merging subtree updates, it is important to select 'Create a merge commit' when merging.**

<!--
@giantswarm/team-cabbage will be automatically requested for review once
this PR has been submitted.
-->

Title says it all. The hack is not required as long as there is another init container around.

## Checklist

- [x] Automated test are working (for chart changes)
- [x] I am confident my changes don't break existing installations (for chart changes)
- [x] Changelog entry has been added
